### PR TITLE
Migrate ESLint config to use ESModule syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,19 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-const js = require("@eslint/js");
-
-const {
-    FlatCompat,
-} = require("@eslint/eslintrc");
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
 
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
+    baseDirectory: import.meta.dirname,
     recommendedConfig: js.configs.recommended,
     allConfig: js.configs.all
 });
 
-module.exports = [{
+export default [{
     ignores: ["projects/**/*"],
 }, ...compat.extends(
     "eslint:recommended",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "frontend",
   "version": "0.11.0",
+  "type":"module",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
Hello

This pull request should fix the issue https://github.com/accrescent/console/issues/16

Using ES module syntax is now possible tanks to https://github.com/angular-eslint/angular-eslint/issues/1859:
![image](https://github.com/user-attachments/assets/8eac97ec-b8cd-4e69-af71-b2fd1a8169bb)

I hope this helps,
Regards